### PR TITLE
Removing _oauthID

### DIFF
--- a/API/GetCookie.js
+++ b/API/GetCookie.js
@@ -69,7 +69,7 @@ function pullOAuthID(req){
         if(x != undefined)
         {
             var s = x.split("=");
-            if(s[0] == 'oAuthId') value = s[1];
+            if(s[0] == '_oAuthId') value = s[1];
         }
     }
     if(value.charAt(value.length - 1) == ';')

--- a/API/users/UserController.js
+++ b/API/users/UserController.js
@@ -95,7 +95,7 @@ exports.create = async function (req, res) {
                     if (err) {
                         res.status(500).json(err);
                     } else {
-			res.cookie('oAuthId', user.oAuthId).json({
+			              res/*.cookie('oAuthId', user.oAuthId)*/.json({
                             message: 'New user created!',
                             data: user
                         });
@@ -149,7 +149,7 @@ User.findById(req.params.user_id, function (err, user) {
                 res.status(500).send(err);
                 return res;
             }
-	    res.cookie('oAuthId', user.oAuthId).json({
+	    res/*.cookie('oAuthId', user.oAuthId)*/.json({
 		status: 'success',
                 message: 'User Info updated',
                 data: user


### PR DESCRIPTION
Still have a duplicate User Id in the body of requests, but now no duplicate Oauth Id, Kept the Oauth Id from the UI because its fresher, and also only required adding a single character on the back end