### PR TITLE
fix url for swagger

### DIFF
--- a/API/index.js
+++ b/API/index.js
@@ -15,7 +15,7 @@ const swaggerOptions = {
 			contact: {
 				name: 'https://github.com/nith822'
 			},
-			servers: ['http://localhost:8080', 'http:razettostone.com']
+			servers: ['http://localhost:8080', 'http:razettostone.com:8080']
 		}
 	},
 	apis: ['index.js', 'posts/PostRoutes.js', 'users/UserRoutes.js']


### PR DESCRIPTION
- Previously swagger didn't have the correct url for Razetto's API endpoint